### PR TITLE
Fix file export crypto

### DIFF
--- a/Tofu/CryptoHelper.swift
+++ b/Tofu/CryptoHelper.swift
@@ -19,14 +19,15 @@ final class CryptoConstants {
     internal static let RandomStringCharSource = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 }
 
+// Based on https://github.com/DigitalLeaves/CommonCrypto-in-Swift
 final class CryptoHelper {
-    ///https://stackoverflow.com/questions/26845307/generate-random-alphanumeric-string-in-swift
-    internal func randomString(length: Int) -> String {
+    // Based on https://stackoverflow.com/questions/26845307/generate-random-alphanumeric-string-in-swift
+    internal static func randomString(length: Int) -> String {
         return String((0..<length).map{ _ in CryptoConstants.RandomStringCharSource.randomElement()! })
     }
     
-    /// https://stackoverflow.com/questions/25388747/sha256-in-swift
-    internal func sha256(data : Data) -> Data {
+    // Based on https://stackoverflow.com/questions/25388747/sha256-in-swift
+    internal static func sha256(data : Data) -> Data {
         var hash = [UInt8](repeating: 0,  count: Int(CC_SHA256_DIGEST_LENGTH))
         data.withUnsafeBytes {
             _ = CC_SHA256($0.baseAddress, CC_LONG(data.count), &hash)
@@ -34,8 +35,10 @@ final class CryptoHelper {
         return Data(hash)
     }
 
-    // Transform a password into a key
-    internal func passwordToKey(password: String, size: Int) -> Data {
+    /// Transform a password into a key.
+    ///
+    /// The key is the hashed password, trimmed/padded to length.
+    internal static func passwordToKey(password: String, size: Int) -> Data {
         let pwdData = password.data(using: .utf8, allowLossyConversion: true)!
         let hashed = self.sha256(data: pwdData)
         if hashed.count == size {
@@ -46,53 +49,41 @@ final class CryptoHelper {
         }
     }
 
-    internal func cryptoOp(password: String, data: Data, operation: CCOperation, iv: Data) -> Data {
-        // MARK: Preparing data for encryption
-        
+    internal static func cryptoOp(password: String, data input: Data, operation: CCOperation, iv: Data) -> Data {
         let key = self.passwordToKey(password: password, size: CryptoConstants.KeySize)
-        // The key is the hashed password, trimmed/padded to length
         
-        let keyBytes = key.withUnsafeBytes { (bytes: UnsafePointer<UInt8>) -> UnsafePointer<UInt8> in
-            return bytes
-        }
-        let dataLength       = Int(data.count)
-        let dataBytes        = data.withUnsafeBytes { (bytes: UnsafePointer<UInt8>) -> UnsafePointer<UInt8> in
-            return bytes
-        }
-        var bufferData       = Data(count: Int(dataLength) + CryptoConstants.BlockSize)
-        let bufferPointer    = bufferData.withUnsafeMutableBytes { (bytes: UnsafeMutablePointer<UInt8>) -> UnsafeMutablePointer<UInt8> in
-            return bytes
-        }
-        let bufferLength     = size_t(bufferData.count)
-        let ivBuffer: UnsafePointer<UInt8>? = iv.withUnsafeBytes({ (bytes: UnsafePointer<UInt8>) -> UnsafePointer<UInt8> in
-            return bytes
-        })
-        var bytesDecrypted   = Int(0)
+        let keyBuffer = key.withUnsafeBytes { return $0 }
+        let ivBuffer = iv.withUnsafeBytes { return $0 }
+
+        let inputBuffer = input.withUnsafeBytes { return $0 }
+
+        var output = Data(count: input.count + CryptoConstants.BlockSize)
+        let outputBuffer = output.withUnsafeMutableBytes { return $0 }
         
-        // MARK: Encrypt
+        var nOutputedBytes = 0
         let cryptStatus = CCCrypt(
-            operation,                  // Operation
-            CryptoConstants.Algorithm,  // Algorithm
-            CryptoConstants.Options,    // Options
-            keyBytes,                   // key data
-            CryptoConstants.KeySize,    // key length
-            ivBuffer,                   // IV buffer
-            dataBytes,                  // input data
-            dataLength,                 // input length
-            bufferPointer,              // output buffer
-            bufferLength,               // output buffer length
-            &bytesDecrypted             // output bytes decrypted real
+            operation,
+            CryptoConstants.Algorithm,
+            CryptoConstants.Options,
+            keyBuffer.baseAddress,    // Key
+            keyBuffer.count,
+            ivBuffer.baseAddress,     // IV
+            inputBuffer.baseAddress,  // Input
+            inputBuffer.count,
+            outputBuffer.baseAddress, // Output
+            outputBuffer.count,
+            &nOutputedBytes           // Result
         )
-        
-        return bufferData as Data
+        assert(cryptStatus == kCCSuccess)
+        return output
     }
 
-    public func encrypt(password: String, data: Data) -> Data {
+    public static func encrypt(password: String, data: Data) -> Data {
         let iv = self.randomString(length: CryptoConstants.IVSize).data(using: .utf8)!
         return iv + self.cryptoOp(password: password, data: data, operation: CCOperation(kCCEncrypt), iv: iv)
     }
 
-    public func decrypt(password: String, data: Data) -> Data {
+    public static func decrypt(password: String, data: Data) -> Data {
         let iv = data.subdata(in: 0 ..< CryptoConstants.IVSize)
         assert(iv.count == CryptoConstants.IVSize)
 

--- a/Tofu/CryptoHelper.swift
+++ b/Tofu/CryptoHelper.swift
@@ -15,15 +15,19 @@ final class CryptoConstants {
     internal static let Options = CCOptions(kCCOptionPKCS7Padding)
     internal static let BlockSize = kCCBlockSizeAES128 // AES256 uses the same block size as AES128
     internal static let IVSize = CryptoConstants.BlockSize // AES IV size is same as block size
-
-    internal static let RandomStringCharSource = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 }
 
 // Based on https://github.com/DigitalLeaves/CommonCrypto-in-Swift
 final class CryptoHelper {
-    // Based on https://stackoverflow.com/questions/26845307/generate-random-alphanumeric-string-in-swift
-    internal static func randomString(length: Int) -> String {
-        return String((0..<length).map{ _ in CryptoConstants.RandomStringCharSource.randomElement()! })
+    internal static func randomData(length: Int) -> Data {
+        var data = Data(count: length)
+        if length != 0 {
+            let eCode = data.withUnsafeMutableBytes { buff in
+                return SecRandomCopyBytes(kSecRandomDefault, length, buff.baseAddress!)
+            }
+            assert(eCode == errSecSuccess)
+        }
+        return data
     }
     
     // Based on https://stackoverflow.com/questions/25388747/sha256-in-swift
@@ -86,7 +90,7 @@ final class CryptoHelper {
     }
 
     public static func encrypt(password: String, data: Data) -> Data {
-        let iv = self.randomString(length: CryptoConstants.IVSize).data(using: .utf8)!
+        let iv = self.randomData(length: CryptoConstants.IVSize)
         return iv + self.cryptoOp(password: password, data: data, operation: CCOperation(kCCEncrypt), iv: iv)
     }
 

--- a/Tofu/Keychain.swift
+++ b/Tofu/Keychain.swift
@@ -121,17 +121,15 @@ class Keychain {
         return SecItemDelete(query as CFDictionary) == errSecSuccess
     }
     
-    /// This function exports all accounts into JSON
-    func uncryptedExport() throws -> Data {
+    /// Export all accounts into JSON
+    internal func uncryptedExport() throws -> Data {
         let encoder = JSONEncoder()
         return try encoder.encode(self.accounts)
     }
     
-    /// This function encrypts the exported data using the provided password
+    /// Exported all accounts, encrypted using the provided password
     func export(password: String) throws -> Data {
-        // I was "inspired" by https://github.com/DigitalLeaves/CommonCrypto-in-Swift
         let json = try self.uncryptedExport()
-        let helper = CryptoHelper()
-        return helper.encrypt(password: password, data: json)
+        return CryptoHelper.encrypt(password: password, data: json)
     }
 }

--- a/TofuTests/EncryptionTests.swift
+++ b/TofuTests/EncryptionTests.swift
@@ -10,14 +10,13 @@ import XCTest
 @testable import Tofu
 
 class EncryptionTests: XCTestCase {
-    func testEncDec() {
+    func testRoundtrip() {
         let data = "example".data(using: .utf8)!
-        
+
         let password = "password"
         let encrypted = CryptoHelper.encrypt(password: password, data: data)
         let decrypted = CryptoHelper.decrypt(password: password, data: encrypted)
-        print("\(decrypted.base64EncodedString())")
-        
+
         XCTAssertEqual(data, decrypted)
     }
 }

--- a/TofuTests/EncryptionTests.swift
+++ b/TofuTests/EncryptionTests.swift
@@ -13,10 +13,9 @@ class EncryptionTests: XCTestCase {
     func testEncDec() {
         let data = "example".data(using: .utf8)!
         
-        let helper = CryptoHelper()
         let password = "password"
-        let encrypted = helper.encrypt(password: password, data: data)
-        let decrypted = helper.decrypt(password: password, data: encrypted)
+        let encrypted = CryptoHelper.encrypt(password: password, data: data)
+        let decrypted = CryptoHelper.decrypt(password: password, data: encrypted)
         print("\(decrypted.base64EncodedString())")
         
         XCTAssertEqual(data, decrypted)

--- a/TofuTests/EncryptionTests.swift
+++ b/TofuTests/EncryptionTests.swift
@@ -11,7 +11,7 @@ import XCTest
 
 class EncryptionTests: XCTestCase {
     func testEncDec() {
-        let data = "example".data(using: .ascii)!
+        let data = "example".data(using: .utf8)!
         
         let helper = CryptoHelper()
         let password = "password"


### PR DESCRIPTION
Here are the fixes as I mentioned in calleerlandsson#30.

What I had to change (see  27db1d8):
 - Remove `kCCOptionECBMode` option. This made is use ECB not CBC.
 - The output data was not being truncated to the length `CCCrypt` stored in the pointer out argument
- The way the `Data` to buffer conversion was done, the buffers did not live long enough. This is a bug already present in the source you copied the code from, so I'll also make a PR there.